### PR TITLE
Support UTC timestamp in millisecond.

### DIFF
--- a/JSONScheme.py
+++ b/JSONScheme.py
@@ -284,7 +284,7 @@ class JSONScheme :
         return False
     
     def getSubType(self) :
-        if self.isNaturalType() :
+        if self.isNaturalType() and self.base_type in JSONScheme.naturalTypeList:
             return self.sub_type
 
         if len(self.sub_type) :

--- a/ObjectiveCCodeGenerator.py
+++ b/ObjectiveCCodeGenerator.py
@@ -691,7 +691,11 @@ class ObjectiveCCodeGenerator :
         elif schemeBaseType == "number" :
             resultString += firstIndent + className + varName + " = [" + self.projectPrefix + "APIParser numberFromResponseDictionary:" + dicName + " forKey:@\"" + keyName + "\" acceptNil:"
         elif schemeBaseType == "date" :
-            resultString += firstIndent + className + varName + " = [" + self.projectPrefix + "APIParser dateWithTimeIntervalFromResponseDictionary:" + dicName + " forKey:@\"" + keyName + "\" acceptNil:"
+            dateObjSubType = schemeObj.getSubType()
+            if len(dateObjSubType) and dateObjSubType[0] == str("ms") :
+                resultString += firstIndent + className + varName + " = [" + self.projectPrefix + "APIParser dateWithMilliSecondsTimeIntervalFromResponseDictionary:" + dicName + " forKey:@\"" + keyName + "\" acceptNil:"
+            else :
+                resultString += firstIndent + className + varName + " = [" + self.projectPrefix + "APIParser dateWithTimeIntervalFromResponseDictionary:" + dicName + " forKey:@\"" + keyName + "\" acceptNil:"
         elif schemeBaseType == "data" :
             resultString += firstIndent + className + varName + " = [" + self.projectPrefix + "APIParser dataFromResponseDictionary:" + dicName + " forKey:@\"" + keyName + "\" acceptNil:"
         elif schemeBaseType == "boolean" :
@@ -900,7 +904,11 @@ class ObjectiveCCodeGenerator :
             if schemeObj.rootBaseType() == "boolean" :
                 returnString += secondIndent + "[" + dicName+ " setObject:[NSNumber numberWithBool:self." + self.makeVarName(schemeObj) + "] forKey:@\"" + schemeObj.type_name + "\"];\n"
             elif schemeObj.rootBaseType() == "date" :
-                returnString += secondIndent + "[" + dicName+ " setObject:[NSNumber numberWithInteger:[[NSNumber numberWithDouble:[self." + self.makeVarName(schemeObj) + " timeIntervalSince1970]] longValue]] forKey:@\"" + schemeObj.type_name + "\"];\n";
+                dateObjSubType = schemeObj.getSubType()
+                if len(dateObjSubType) and dateObjSubType[0] == str("ms") :
+                    returnString += secondIndent + "[" + dicName+ " setObject:[NSNumber numberWithInteger:[[NSNumber numberWithDouble:[self." + self.makeVarName(schemeObj) + " timeIntervalSince1970]] longValue] * 1000] forKey:@\"" + schemeObj.type_name + "\"];\n";
+                else :
+                    returnString += secondIndent + "[" + dicName+ " setObject:[NSNumber numberWithInteger:[[NSNumber numberWithDouble:[self." + self.makeVarName(schemeObj) + " timeIntervalSince1970]] longValue]] forKey:@\"" + schemeObj.type_name + "\"];\n";
             elif schemeObj.rootBaseType() == "array" :
                 arrayObjType = schemeObj.getSubType()
                 if arrayObjType and len(arrayObjType) == 1 and schemeObj.hasScheme(arrayObjType[0]) == True :

--- a/doc/MetaJSONProtocol.md
+++ b/doc/MetaJSONProtocol.md
@@ -56,6 +56,7 @@ You can also use just one of those ("minValue" or "maxValue").
 {
 	"name" : "myDate",
 	"base-type" : "date",
+	"subType" : "ms",
 	"description" : string
 	"minValue" : UTC time interval since 1970
 	"maxValue" : UTC time interval since 1970
@@ -63,6 +64,8 @@ You can also use just one of those ("minValue" or "maxValue").
 ```
 	
 * The value of myDate should be always UTC time interval since 1970.
+* "subType" is optional, to specify wheather it's millisecond based timestamp or second based timestamp.
+* If "subType" is specified as "ms", "minValue" and "maxValue" should be used like "1382455623.098"
 * "minValue" and "maxValue" are optional, to validate this type.
 * "maxValue" should be always same or later than "minValue".
 	

--- a/doc/known_issues.md
+++ b/doc/known_issues.md
@@ -16,6 +16,9 @@ A definition like below which might be referenced as sub or base type is not yet
 }
 ```
 
+###Documentation Topic 4
+java code generator doesn't support "subType" for "date" type yet.
+
 ###Documentation Topic 12
 The complete topic 12 is not yet fully supported and/or tested. Some parts might already work but there is no intentionally support implemented yet.
 


### PR DESCRIPTION
For Objective-C, from now metaJSON supports UTC timestamp in millisecond with "date" primitive data scheme.
