### PR TITLE
fix Bug : when the root parent scheme didn't have any property, generate...

### DIFF
--- a/JSONScheme.py
+++ b/JSONScheme.py
@@ -236,8 +236,8 @@ class JSONScheme :
     
     def getClassName(self):
         
-        if self.rootBaseType() == "object" :
-            if self.props : 
+        if self.rootBaseType() == "object":
+            if self.props or self.base_type == "object": 
                 className = self.type_name.upper()
                 className = self.projectPrefix + className[:1] + self.type_name[1:] + self.objectSuffix
             else : # it means, this scheme descripe just property info, not class info. 


### PR DESCRIPTION
when the root parent scheme didn't have any property, generated class name and file name were wrong.
