### PR TITLE
Fix bug in dateWithMilliSecondsTimeIntervalFromResponseDictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ json2yaml -d 5 test.json > test.yaml
 
 ## Documentation
 
-See MetaJSONProtocol.md file in the doc folder.
+See [MetaJSONProtocol.md](doc/MetaJSONProtocol.md) file in the doc folder.
 
 ## Known issues
-Please check the issue tracker and/or refer to the known_issues.md file in the doc folder.
+Please check the issue tracker and/or refer to the [known_issues.md](doc/known_issues.md) file in the doc folder.
 
 ## License
 The project is published with the MIT License. Please read the LICENSE.txt for more details.

--- a/templates/APIParser/APIParser.m
+++ b/templates/APIParser/APIParser.m
@@ -575,7 +575,7 @@ if (!(error)) (error) = (NSError*__autoreleasing*)alloca(sizeof(NSError*));     
         return nil;
     }
     
-    NSNumber *timeInterval = [NSNumber numberWithLongLong:(dateNumber.longLongValue / 1000)];
+    NSNumber *timeInterval = [NSNumber numberWithDouble:(dateNumber.doubleValue / 1000)];
     
     if (*error || !timeInterval || ![timeInterval isKindOfClass:[NSNumber class]])
     {

--- a/templates/APIParser/APIParser.m
+++ b/templates/APIParser/APIParser.m
@@ -584,7 +584,7 @@ if (!(error)) (error) = (NSError*__autoreleasing*)alloca(sizeof(NSError*));     
         return nil;
     }
     
-    NSDate *date = [NSDate dateWithTimeIntervalSince1970:[timeInterval longLongValue]];
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:[timeInterval doubleValue]];
     
     return date;
 }


### PR DESCRIPTION
always use double value.
