### PR TITLE
Fixing tests broken due to copyright timestamp

### DIFF
--- a/test/ObjectiveCCodeGenerator_test.py
+++ b/test/ObjectiveCCodeGenerator_test.py
@@ -5,6 +5,7 @@ import pickle
 import unittest
 import sys
 import os
+import datetime
 
 class TestObjectiveCCodeGenerator(unittest.TestCase):
     def setUp(self):
@@ -39,7 +40,8 @@ class TestObjectiveCCodeGenerator(unittest.TestCase):
     def assert_content_file(self, filename, content):
         with open(filename, 'r') as content_file:
             expected_result = content_file.read()
-        self.assertMultiLineEqual(content, expected_result)
+        # All reference files have a timestamp of 2014 so we tweak our generated code to match them.
+        self.assertMultiLineEqual(content.replace(str(datetime.datetime.now().year), "2014"), expected_result)
 
 class TestSampleTestClassCase(TestObjectiveCCodeGenerator):
     def setUp(self):

--- a/test/readJSON_test.py
+++ b/test/readJSON_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import datetime
 
 class TestReadJSON(unittest.TestCase):
     def setUp(self):
@@ -23,6 +24,9 @@ class TestReadJSON(unittest.TestCase):
         # common_file = "/AbstractInterfaceFiles/_SenderList2JSONObject.m"
         # common_file = "/AbstractInterfaceFiles/_SenderJSONObject.m"
         # common_file = "/AbstractInterfaceFiles/_SenderGroupJSONObject.m"
+        
+        # All timestamps in reference files should be 2014, so we need to tweak our generated files to match them.
+        os.system("find src -type f -exec sed -r --in-place \"s/%d/2014/g\" {} +" % (datetime.datetime.now().year, ) )
         return os.system("diff -r -w -b -B src " + output_dir)
         # return os.system("diff -r -w -b -B src" + common_file + " " + output_dir + common_file)
 


### PR DESCRIPTION
All tests have failed since 2015-01-01 because the timestamp at the copyright notice of the generated files differs from the timestamp of reference file's copyright notice which is of 2014.

This is fixed by replacing all occurences of the current year in the generated files with "2014". Keep in mind that even new reference files need a timestamp of 2014 for the tests to work.
